### PR TITLE
Fixed sorting issue #1

### DIFF
--- a/ticketing/models.py
+++ b/ticketing/models.py
@@ -55,6 +55,7 @@ class TicketTable(tables.Table):
         verbose_name="Ticket ID",
         attrs={"a": {"style": "color:black"}},
     )
+    t_subject = tables.Column(verbose_name="Subject", order_by="t_subject_lower")
 
     class Meta:
         model = Ticket


### PR DESCRIPTION
Adding an annotation for the queryset fixes the issue #1 by passing the ```Lower()``` function to the django-tables2 table. 

Then to set the default sort type, we just check to see if the ```sort_by``` variable begins with an '-' or not, and sort with ```.asc()``` or ```.desc()``` depending on the result of the if statement.